### PR TITLE
Run Sonar Build Wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(learning-media-foundation VERSION 0.1.2 LANGUAGES CXX)
+project(learning-media-foundation VERSION 0.1.3 LANGUAGES CXX)
 
 set(CMAKE_SUPPRESS_REGENERATION true)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,15 +1,15 @@
 {
-    "version": 2,
+    "version": 3,
     "cmakeMinimumRequired": {
         "major": 3,
-        "minor": 20,
+        "minor": 21,
         "patch": 0
     },
     "configurePresets": [
         {
             "name": "x64-windows-debug",
             "displayName": "vcpkg(x64-windows) debug",
-            "generator": "Visual Studio 16 2019",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build-x64-windows",
             "cacheVariables": {
                 "BUILD_TESTING": "ON",
@@ -28,7 +28,7 @@
         {
             "name": "x64-windows-release",
             "displayName": "vcpkg(x64-windows) release",
-            "generator": "Visual Studio 16 2019",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build-x64-windows",
             "cacheVariables": {
                 "BUILD_TESTING": "ON",
@@ -50,7 +50,7 @@
         {
             "name": "x86-windows-debug",
             "displayName": "vcpkg(x86-windows) debug",
-            "generator": "Visual Studio 16 2019",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build-x86-windows",
             "cacheVariables": {
                 "BUILD_TESTING": "ON",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,6 +114,7 @@ jobs:
             sonar.verbose=true
             sonar.cfamily.threads=4
             sonar.cfamily.build-wrapper-output=bw-output
+            sonar.testExecutionReportPaths=build-x64-windows/sonar-test-report.xml
       # https://github.com/SonarSource/sonarcloud_example_cpp-cmake-windows-otherci
       - powershell: |
           Invoke-WebRequest -Uri "https://sonarcloud.io/static/cpp/build-wrapper-win-x86.zip" -OutFile build-wrapper-win.zip
@@ -131,11 +132,12 @@ jobs:
       - powershell: |
           $env:Path="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Msbuild\Current\Bin;$env:Path"
           MSBuild --version
-          ./build-wrapper-win-x86-64.exe --out-dir "../bw-output" `
+          ./build-wrapper-win-x86-64.exe --out-dir "$(Build.SourcesDirectory)/../bw-output" `
             MSBuild build-x64-windows/learning-media-foundation.sln `
             /t:rebuild /p:platform="x64" /p:configuration="Debug"
-        displayName: "Sonar Build Wrapper"
-      - powershell: ./media_test_suite.exe
+        displayName: "Run Sonar Build Wrapper"
+      # https://docs.sonarqube.org/latest/analysis/generic-test/
+      - powershell: ./media_test_suite.exe --reporter=sonarqube --out "$(Build.SourcesDirectory)/build-x64-windows/sonar-test-report.xml"
         workingDirectory: build-x64-windows/Debug
         displayName: "Run Tests"
       # - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,6 +119,7 @@ jobs:
           Invoke-WebRequest -Uri "https://sonarcloud.io/static/cpp/build-wrapper-win-x86.zip" -OutFile build-wrapper-win.zip
           Expand-Archive -Path "build-wrapper-win.zip" -DestinationPath .
           Move-Item -Path "./build-wrapper-win-x86/build-wrapper-win-x86-64.exe" -Destination .
+        displayName: "Download: Sonar Build Wrapper"
       - task: CMake@1
         displayName: "CMake: Configure/Generate"
         inputs:
@@ -133,14 +134,17 @@ jobs:
           ./build-wrapper-win-x86-64.exe --out-dir "../bw-output" `
             MSBuild build-x64-windows/learning-media-foundation.sln `
             /t:rebuild /p:platform="x64" /p:configuration="Debug"
-      # - powershell: ./media_test_suite.exe
-      #   workingDirectory: build-x64-windows/Debug
-      #   displayName: "Run Tests"
+        displayName: "Sonar Build Wrapper"
+      - powershell: ./media_test_suite.exe
+        workingDirectory: build-x64-windows/Debug
+        displayName: "Run Tests"
       # - task: PowerShell@2
       #   displayName: "Create XML from coverage"
       #   inputs:
       #     filePath: "scripts/create-coverage-xml.ps1"
       - task: SonarCloudAnalyze@1
+        continueOnError: true
       - task: SonarCloudPublish@1
         inputs:
           pollingTimeoutSec: "300"
+        continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ variables:
 jobs:
   - job: Build
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2022"
     strategy:
       matrix:
         release_x64:
@@ -85,7 +85,7 @@ jobs:
   - job: Analysis
     dependsOn: Build
     pool:
-      vmImage: "windows-2019"
+      vmImage: "windows-2022"
     steps:
       - task: Cache@2
         inputs:
@@ -117,9 +117,9 @@ jobs:
             sonar.cfamily.build-wrapper-output=bw-output
       # https://github.com/SonarSource/sonarcloud_example_cpp-cmake-windows-otherci
       - powershell: |
-          Invoke-WebRequest -Uri http://sonarcloud.io/static/cpp/build-wrapper-win-x86_64.zip -OutFile build-wrapper-win.zip
-          Expand-Archive -Path build-wrapper-win.zip -DestinationPath .
-          Move-Item ./build-wrapper-win-x86/build-wrapper-win-x86-64.exe .
+          Invoke-WebRequest -Uri "https://sonarcloud.io/static/cpp/build-wrapper-win-x86.zip" -OutFile build-wrapper-win.zip
+          Expand-Archive -Path "build-wrapper-win.zip" -DestinationPath .
+          Move-Item -Path "./build-wrapper-win-x86/build-wrapper-win-x86-64.exe" -DestinationPath .
       - task: CMake@1
         displayName: "CMake: Configure/Generate"
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,10 @@ jobs:
         inputs:
           key: '2022-02 | vcpkg | x64'
           path: $(vcpkg.default.binary.cache)
+      - task: Cache@2
+        inputs:
+          key: '2022-02 | sonarqube'
+          path: $(Pipeline.Workspace)/.sonarqube
       - task: run-vcpkg@0
         displayName: "Install: Vcpkg"
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
   - job: Analysis
     dependsOn: Build
     pool:
-      vmImage: "windows-2022"
+      vmImage: "windows-2022" # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
     steps:
       - task: Cache@2
         inputs:
@@ -129,8 +129,10 @@ jobs:
       # https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-azure-devops/
       # https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/
       - powershell: |
+          $env:Path="C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Msbuild\Current\Bin;$env:Path"
+          MSBuild --version
           ./build-wrapper-win-x86-64.exe --out-dir "../bw-output" `
-            MSBuild.exe build-x64-windows/learning-media-foundation.sln `
+            MSBuild build-x64-windows/learning-media-foundation.sln `
             /t:rebuild /p:platform="x64" /p:configuration="Debug"
       - task: SonarCloudAnalyze@1
       - task: SonarCloudPublish@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,6 @@ jobs:
       - powershell: New-Item -Type Directory -Force ${env:VCPKG_DEFAULT_BINARY_CACHE}
       - task: PowerShell@2
         inputs:
-          targetType: "filepath"
           filePath: "scripts/download_mp4.ps1"
       - task: Cache@2
         inputs:
@@ -108,7 +107,7 @@ jobs:
           projectVersion: "0.1.3"
           extraProperties: |
             sonar.language=c++
-            sonar.cpp.std=c++17
+            sonar.cpp.std=c++20
             sonar.sourceEncoding=UTF-8
             sonar.sources=src/,test/
             sonar.exclusions=scripts/
@@ -134,6 +133,13 @@ jobs:
           ./build-wrapper-win-x86-64.exe --out-dir "../bw-output" `
             MSBuild build-x64-windows/learning-media-foundation.sln `
             /t:rebuild /p:platform="x64" /p:configuration="Debug"
+      # - powershell: ./media_test_suite.exe
+      #   workingDirectory: build-x64-windows/Debug
+      #   displayName: "Run Tests"
+      # - task: PowerShell@2
+      #   displayName: "Create XML from coverage"
+      #   inputs:
+      #     filePath: "scripts/create-coverage-xml.ps1"
       - task: SonarCloudAnalyze@1
       - task: SonarCloudPublish@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ schedules:
 
 variables:
   - name: vcpkg.commit
-    value: "5ddd7f02689b7c5aab78711d77f61db5d2e5e79c" # mainstream 2021-12-01
+    value: "b86c0c35b88e2bf3557ff49dc831689c2f085090" # mainstream 2022.02.23
   - name: vcpkg.feature.flags
     value: "registries,binarycaching"
   - name: vcpkg.default.binary.cache
@@ -46,7 +46,7 @@ jobs:
           filePath: "scripts/download_mp4.ps1"
       - task: Cache@2
         inputs:
-          key: '2019-02 | vcpkg | $(build.platform)'
+          key: '2022-02 | vcpkg | $(build.platform)'
           path: $(vcpkg.default.binary.cache)
       - task: run-vcpkg@0
         displayName: "Install: Vcpkg"
@@ -89,7 +89,7 @@ jobs:
     steps:
       - task: Cache@2
         inputs:
-          key: '2019-02 | vcpkg | x64'
+          key: '2022-02 | vcpkg | x64'
           path: $(vcpkg.default.binary.cache)
       - task: run-vcpkg@0
         displayName: "Install: Vcpkg"
@@ -119,7 +119,7 @@ jobs:
       - powershell: |
           Invoke-WebRequest -Uri "https://sonarcloud.io/static/cpp/build-wrapper-win-x86.zip" -OutFile build-wrapper-win.zip
           Expand-Archive -Path "build-wrapper-win.zip" -DestinationPath .
-          Move-Item -Path "./build-wrapper-win-x86/build-wrapper-win-x86-64.exe" -DestinationPath .
+          Move-Item -Path "./build-wrapper-win-x86/build-wrapper-win-x86-64.exe" -Destination .
       - task: CMake@1
         displayName: "CMake: Configure/Generate"
         inputs:

--- a/scripts/create-coverage-xml.ps1
+++ b/scripts/create-coverage-xml.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    PowerShell script to create coverage for SonarCloud Analysis
+.DESCRIPTION
+    https://docs.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested
+#>
+using namespace System
+
+# Codecoverage.exe (Azure Pipelines)
+env:Path = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Team Tools\Dynamic Code Coverage Tools;$env:Path"
+
+# Acquire coverage file and generate temporary coverage file
+$coverage_file = Get-ChildItem -Recurse "*.coverage";
+if ($null -eq $coverage_file) {
+    Write-Output "coverage file not found"
+    return
+}
+Write-Output $coverage_file
+
+$temp_coverage_xml_filepath = "./TestResults/coverage-report.xml"
+CodeCoverage analyze /verbose /output:$temp_coverage_xml_filepath $coverage_file
+
+Get-ChildItem "./TestResults"
+
+# Filter lines with invalid line number 
+#   and Create a new coverage xml
+# $final_coverage_xml_filepath = "./TestResults/luncliff-media.coveragexml"
+# $xml_lines = Get-Content $temp_coverage_xml_filepath
+# foreach ($text in $xml_lines) {
+#     if ($text -match 15732480) {
+#         Write-Output "removed $text"
+#         continue;
+#     }
+#     else {
+#         Add-Content $final_coverage_xml_filepath $text;
+#     }
+# }
+# Tree ./TestResults /F
+
+# Display information of a new coverage xml
+# Get-ChildItem $final_coverage_xml_filepath
+# Get-Content   $final_coverage_xml_filepath

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,7 @@ sonar.projectDescription=Personal practice project to learn Microsoft Media Foun
 sonar.projectVersion=0.1.2
 
 sonar.language=c++
-sonar.cpp.std=c++17
+sonar.cpp.std=c++20 # It's for the static analysis
 sonar.sourceEncoding=UTF-8
 sonar.sources=src/,test/
 sonar.exclusions=build-x64-windows/,docs/

--- a/test/test_dxva.cpp
+++ b/test/test_dxva.cpp
@@ -4,28 +4,28 @@
 #include <d3d11_4.h>
 #include <d3d9.h>
 #include <mfapi.h>
-#include <windows.h>
+#include <Windows.h>
 #include <windowsx.h>
 
-#include <Dxva2api.h>
+#include <dxva2api.h>
 #include <codecapi.h> // for [codec]
 #include <evr.h>
 #include <mediaobj.h> // for [dsp]
 #include <mfplay.h>
 #include <mmdeviceapi.h>
 #include <ppl.h>
-#include <shlwapi.h>
+#include <Shlwapi.h>
 #include <wmsdkidl.h>
 //#pragma comment(lib, "strmiids") // for MR_VIDEO_RENDER_SERVICE
 // clang-format on
 
-#include <Inspectable.h>  // IInspectable
 #include <MemoryBuffer.h> // IMemoryBufferByteAccess
 #include <filesystem>
+#include <inspectable.h> // IInspectable
+#include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
 #include <winrt/Windows.Graphics.Imaging.h>
 #include <winrt/base.h>
-#include <winrt/windows.foundation.h>
 
 #include <DirectXTK/DirectXHelpers.h>
 #include <DirectXTex.h>

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -56,8 +56,9 @@ class test_suite_context_t final {
     }
 
     void use_environment(wchar_t* envp[]) {
-        if (envp)
-            spdlog::debug("envs:");
+        if (envp == nullptr)
+            return;
+        spdlog::debug("envs:");
         for (wchar_t** ptr = envp; (*ptr) != nullptr; ++ptr)
             spdlog::debug(" - {}", winrt::to_string(std::wstring_view{*ptr}));
     }


### PR DESCRIPTION
### Changes

**Recover code analysis: https://sonarcloud.io/project/overview?id=luncliff-media**

Requires [CMake 3.21](https://cmake.org/cmake/help/v3.21/manual/cmake-presets.7.html). VS2019 was using 3.20.

Find MSBuild under `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Msbuild\Current\Bin`. This is for [`windows-2022`](https://github.com/actions/virtual-environments/tree/main/images) build image.

Report XML report with `sonar.testExecutionReportPaths`.

create-coverage-xml.ps1 file is a temporary work. It will be used when `vstest.console.exe` becomes available.

### To Do

* [ ] Support `vstest.console.exe` for CI jobs. The tool uses DLL. So additional test implementation is required.

### References

* https://github.com/actions/virtual-environments/tree/main/images
* https://docs.sonarcloud.io/enriching/test-coverage/test-coverage-parameters
* https://docs.microsoft.com/en-us/visualstudio/test/using-code-coverage-to-determine-how-much-code-is-being-tested

